### PR TITLE
feat: add gRPC max message size configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/rollkit/go-sequencing v0.4.1
 	github.com/rollkit/rollkit v0.14.1
 	github.com/stretchr/testify v1.10.0
+	google.golang.org/grpc v1.67.1
 )
 
 require (
@@ -98,7 +99,6 @@ require (
 	golang.org/x/text v0.18.0 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240827150818-7e3bb234dfed // indirect
-	google.golang.org/grpc v1.67.1 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.3.0 // indirect


### PR DESCRIPTION

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Introduce a `--max-msg-size` flag to configure the maximum gRPC message size for receiving and sending. Update the gRPC server initialization to include these size limits, ensuring better control over large message handling.


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a command-line option to set the maximum gRPC message size, giving users greater flexibility in handling various message loads.
	- Updated the server’s startup logging to display the active listening address, providing clearer runtime information.
- **Dependencies**
	- Added `google.golang.org/grpc v1.67.1` as a direct dependency for enhanced gRPC functionality.
	- Removed the indirect inclusion of `google.golang.org/grpc v1.67.1`, streamlining dependency management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->